### PR TITLE
Form conditions doesn't work with nette ~2.3.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - NETTE_VERSION="~2.0.0"
   - NETTE_VERSION="~2.1.0"
   - NETTE_VERSION="~2.2.0"
+  - NETTE_VERSION="~2.3.0"
   - NETTE_VERSION="dev-master"
 
 before_script:

--- a/tests/DateInput.condition.phpt
+++ b/tests/DateInput.condition.phpt
@@ -1,0 +1,23 @@
+<?php
+
+use Vodacek\Forms\Controls\DateInput;
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+test(
+	function() {
+	$form = new Nette\Forms\Form();
+	$control = new DateInput('date', DateInput::TYPE_DATE);
+	$form->addComponent($control, 'input');
+
+	$control->addCondition(\Nette\Forms\Form::FILLED)
+            ->addRule(\Nette\Forms\Form::VALID, "invalid date");
+
+	$control->setValue('2000-01-01');
+
+	$form->isValid();
+
+	Assert::false($control->hasErrors());
+	Assert::type('DateTime', $control->getValue());
+});


### PR DESCRIPTION
I added test to show not working status.
Conditions doesn't work on nette version ~2.3.0 and dev-master.

Functions validateFilled, validateDateInputValid and validateValid are not used.
Nette\Forms use own functions to validate data. It make infinity loop.

On web server it makes empty response if form is submmited.

I think problem is in [Nette/Forms src/Forms/Rules.php:285](https://github.com/nette/forms/blob/v2.3.6/src/Forms/Rules.php#L285)
