### PR TITLE
opt-in support of DateTimeImmutable

### DIFF
--- a/tests/DateInput.immutable.phpt
+++ b/tests/DateInput.immutable.phpt
@@ -1,0 +1,15 @@
+<?php
+
+use Vodacek\Forms\Controls\DateInput;
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+DateInput::register(true);
+
+test(function() { // valid submitted value
+	$control = new DateInput('date', DateInput::TYPE_DATE);
+	$control->setValue('2014-02-14');
+	Assert::type(DateTimeImmutable::class, $control->getValue());
+	Assert::equal(new DateTimeImmutable('2014-02-14 00:00:00'), $control->getValue());
+});


### PR DESCRIPTION
Added the support of the immutable variant I really lack.

The class now accepts DateTimeInterface on input so it tolerates both mutable and immutable variant. Generating immutable version can be turned on using DateInput::register(true);